### PR TITLE
refactor: modernize main.go, fix exclude and config edge cases

### DIFF
--- a/cmd/pr-size-labeler-action/main.go
+++ b/cmd/pr-size-labeler-action/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -189,15 +190,44 @@ func getConfigFilePath(providedPath string) string {
 	return providedPath
 }
 
-// loadConfig loads the configuration from the YAML file.
+// loadConfig loads and validates the configuration from the YAML file.
 func loadConfig(filePath string) (Config, error) {
 	var config Config
+
 	yamlFile, err := os.ReadFile(filePath)
 	if err != nil {
-		return config, err
+		return config, fmt.Errorf("reading %s: %w", filePath, err)
 	}
-	err = yaml.Unmarshal(yamlFile, &config)
-	return config, err
+
+	if err := yaml.Unmarshal(yamlFile, &config); err != nil {
+		return config, fmt.Errorf("parsing %s: %w", filePath, err)
+	}
+
+	if err := validateConfig(config); err != nil {
+		return config, fmt.Errorf("invalid configuration in %s: %w", filePath, err)
+	}
+
+	return config, nil
+}
+
+// validateConfig checks that the configuration can actually be used to pick a
+// label, so a malformed file fails with a readable message instead of a panic
+// further down.
+func validateConfig(config Config) error {
+	if len(config.LabelConfigs) == 0 {
+		return errors.New("label_configs must contain at least one entry")
+	}
+
+	for i, entry := range config.LabelConfigs {
+		if entry.Size == "" {
+			return fmt.Errorf("label_configs[%d]: size must not be empty", i)
+		}
+		if len(entry.Labels) == 0 {
+			return fmt.Errorf("label_configs[%d] (%s): labels must not be empty", i, entry.Size)
+		}
+	}
+
+	return nil
 }
 
 // fetchPullRequestFiles fetches the list of files in a pull request, following

--- a/cmd/pr-size-labeler-action/main.go
+++ b/cmd/pr-size-labeler-action/main.go
@@ -329,10 +329,10 @@ func shouldExcludeFile(filename string, patterns []string) bool {
 			return true
 		}
 
-		// Check if the pattern specifies a directory and matches the beginning of the filename
-		if strings.HasSuffix(pattern, "/*") {
-			dirPattern := filepath.Dir(pattern)
-			if strings.HasPrefix(filename, dirPattern) {
+		// A trailing "/*" excludes the directory recursively, which filepath.Match
+		// cannot express because its wildcards never cross a separator.
+		if dir, ok := strings.CutSuffix(pattern, "/*"); ok {
+			if strings.HasPrefix(filename, dir+"/") {
 				return true
 			}
 		}

--- a/cmd/pr-size-labeler-action/main.go
+++ b/cmd/pr-size-labeler-action/main.go
@@ -5,16 +5,17 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"runtime"
 	"slices"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/alexflint/go-arg"
 	"github.com/google/go-github/v90/github"
-	"golang.org/x/oauth2"
 	"gopkg.in/yaml.v3"
 )
 
@@ -33,7 +34,7 @@ type EnvArgs struct {
 	PrNumber            string `arg:"env:PULL_REQUEST_NUMBER,required"`
 	RepoName            string `arg:"env:GITHUB_REPOSITORY,required"`
 	ConfigFilePath      string `arg:"env:CONFIG_FILE_PATH"`
-	GitHubEnterpriseUrl string `arg:"env:GITHUB_ENTERPRISE_URL"`
+	GitHubEnterpriseURL string `arg:"env:GITHUB_ENTERPRISE_URL"`
 }
 
 // Version returns a formatted string with application version details.
@@ -44,8 +45,6 @@ func (EnvArgs) Version() string {
 // Constants for default configuration and event names.
 const (
 	DefaultConfigPath = ".github/pull-request-size.yml"
-	ParamNameFiles    = "files"
-	ParamNameDiff     = "diff"
 
 	// maxFilesPerPage is the largest page size the GitHub API accepts for
 	// listing pull request files.
@@ -67,29 +66,34 @@ type Config struct {
 	AddedLinesOnly bool          `yaml:"added_lines_only"`
 }
 
+// thresholdFunc reads the threshold a ConfigEntry defines for one of the two
+// size axes.
+type thresholdFunc func(ConfigEntry) int
+
+// filesThreshold returns the file count threshold of an entry.
+func filesThreshold(entry ConfigEntry) int { return entry.Files }
+
+// diffThreshold returns the changed lines threshold of an entry.
+func diffThreshold(entry ConfigEntry) int { return entry.Diff }
+
 // GitHubClientWrapper wraps the GitHub client for ease of testing and abstraction.
 type GitHubClientWrapper struct {
 	client *github.Client
 }
 
 // NewGitHubClientWrapper creates a new wrapper for the GitHub client.
-func NewGitHubClientWrapper(token, gitHubEnterpriseUrl string) *GitHubClientWrapper {
-	ctx := context.Background()
-	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-	tc := oauth2.NewClient(ctx, ts)
-
-	opts := []github.ClientOptionsFunc{github.WithHTTPClient(tc)}
-	if gitHubEnterpriseUrl != "" {
-		opts = append(opts, github.WithEnterpriseURLs(gitHubEnterpriseUrl, gitHubEnterpriseUrl))
+func NewGitHubClientWrapper(token, gitHubEnterpriseURL string) (*GitHubClientWrapper, error) {
+	opts := []github.ClientOptionsFunc{github.WithAuthToken(token)}
+	if gitHubEnterpriseURL != "" {
+		opts = append(opts, github.WithEnterpriseURLs(gitHubEnterpriseURL, gitHubEnterpriseURL))
 	}
 
 	client, err := github.NewClient(opts...)
 	if err != nil {
-		fmt.Printf("Failed to create GitHub client: %v\n", err)
-		os.Exit(1)
+		return nil, err
 	}
 
-	return &GitHubClientWrapper{client: client}
+	return &GitHubClientWrapper{client: client}, nil
 }
 
 // PullRequestProcessor handles the processing of a single pull request.
@@ -115,62 +119,70 @@ func NewPullRequestProcessor(ctx context.Context, clientWrapper *GitHubClientWra
 }
 
 // ProcessPullRequest processes the files of a pull request and applies labels accordingly.
-func (prp *PullRequestProcessor) ProcessPullRequest() {
+func (prp *PullRequestProcessor) ProcessPullRequest() error {
 	files, err := prp.fetchPullRequestFiles()
 	if err != nil {
-		exitOnError("fetching pull request files", err)
-		return
+		return fmt.Errorf("fetching pull request files: %w", err)
 	}
 
 	numberOfFiles, numberOfLines := calculateSizeAndDiff(files, prp.config)
 	size, diff := mapNumberOfChangesToSize(numberOfFiles, numberOfLines, prp.config)
 	biggestEntry := getBiggestEntry(prp.config.LabelConfigs, size, diff)
 
-	err = prp.updatePullRequestLabel(biggestEntry)
-	if err != nil {
-		exitOnError("updating pull request label", err)
+	if err := prp.updatePullRequestLabel(biggestEntry); err != nil {
+		return fmt.Errorf("updating pull request label: %w", err)
 	}
+
+	return nil
 }
 
 func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// run wires everything together and reports the first error it hits.
+func run() error {
 	var args EnvArgs
 	arg.MustParse(&args)
 
 	if !isValidGitHubEventType(args.EventName) || !isValidRepoFormat(args.RepoName) {
-		return
+		return nil
 	}
 
 	prNumber, err := strconv.Atoi(args.PrNumber)
 	if err != nil {
-		exitOnError("parsing pull request number", err)
-		return
+		return fmt.Errorf("parsing pull request number %q: %w", args.PrNumber, err)
 	}
 
 	config, err := loadConfig(getConfigFilePath(args.ConfigFilePath))
 	if err != nil {
-		exitOnError("loading configuration", err)
-		return
+		return fmt.Errorf("loading configuration: %w", err)
 	}
 
-	ctx := context.Background()
-	clientWrapper := NewGitHubClientWrapper(args.GithubToken, args.GitHubEnterpriseUrl)
-	prProcessor := NewPullRequestProcessor(ctx, clientWrapper, parseRepoOwner(args.RepoName), parseRepoName(args.RepoName), prNumber, config)
-	prProcessor.ProcessPullRequest()
+	clientWrapper, err := NewGitHubClientWrapper(args.GithubToken, args.GitHubEnterpriseURL)
+	if err != nil {
+		return fmt.Errorf("creating GitHub client: %w", err)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	processor := NewPullRequestProcessor(ctx, clientWrapper, parseRepoOwner(args.RepoName), parseRepoName(args.RepoName), prNumber, config)
+	return processor.ProcessPullRequest()
 }
 
 // isValidGitHubEventType checks if the event name is a valid pull request event.
 func isValidGitHubEventType(eventName string) bool {
-	allowedEvents := map[string]bool{
-		"pull_request":        true,
-		"pull_request_target": true,
-	}
-
-	if allowedEvents[strings.ToLower(eventName)] {
+	switch strings.ToLower(eventName) {
+	case "pull_request", "pull_request_target":
 		return true
+	default:
+		fmt.Println("Event is not a valid pull request event, doing nothing")
+		return false
 	}
-
-	fmt.Println("Event is not a valid pull request event, doing nothing")
-	return false
 }
 
 // isValidRepoFormat checks if the repository name follows the 'owner/repository' format.
@@ -255,57 +267,54 @@ func (prp *PullRequestProcessor) fetchPullRequestFiles() ([]*github.CommitFile, 
 func (prp *PullRequestProcessor) updatePullRequestLabel(entry ConfigEntry) error {
 	pr, _, err := prp.clientWrapper.client.PullRequests.Get(prp.ctx, prp.repoOwner, prp.repoName, prp.prNumber)
 	if err != nil {
-		return err
+		return fmt.Errorf("fetching pull request: %w", err)
 	}
 
-	err = removeOtherSizeLabels(prp.ctx, prp.clientWrapper.client, prp.repoOwner, prp.repoName, prp.prNumber, pr, prp.config, entry)
-	if err != nil {
+	if err := prp.removeOtherSizeLabels(pr, entry); err != nil {
 		return err
 	}
 
 	for _, label := range entry.Labels {
-		labelExists := labelExists(pr, label)
-		if !labelExists {
-			_, _, err = prp.clientWrapper.client.Issues.AddLabelsToIssue(prp.ctx, prp.repoOwner, prp.repoName, prp.prNumber, []string{label})
-			if err != nil {
-				return err
-			}
+		if labelExists(pr, label) {
+			continue
+		}
+
+		if _, _, err := prp.clientWrapper.client.Issues.AddLabelsToIssue(prp.ctx, prp.repoOwner, prp.repoName, prp.prNumber, []string{label}); err != nil {
+			return fmt.Errorf("adding label %q: %w", label, err)
 		}
 	}
+
 	return nil
 }
 
 // removeOtherSizeLabels removes labels that are different from the current size labels.
-func removeOtherSizeLabels(ctx context.Context, client *github.Client, repoOwner, repoName string, prNumber int, pr *github.PullRequest, config Config, entry ConfigEntry) error {
+func (prp *PullRequestProcessor) removeOtherSizeLabels(pr *github.PullRequest, entry ConfigEntry) error {
 	for _, label := range pr.Labels {
-		if isSizeLabel(label.GetName(), config.LabelConfigs) && !contains(entry.Labels, label.GetName()) {
-			_, err := client.Issues.RemoveLabelForIssue(ctx, repoOwner, repoName, prNumber, label.GetName())
-			if err != nil {
-				return err
-			}
+		name := label.GetName()
+		if !isSizeLabel(name, prp.config.LabelConfigs) || slices.Contains(entry.Labels, name) {
+			continue
+		}
+
+		if _, err := prp.clientWrapper.client.Issues.RemoveLabelForIssue(prp.ctx, prp.repoOwner, prp.repoName, prp.prNumber, name); err != nil {
+			return fmt.Errorf("removing label %q: %w", name, err)
 		}
 	}
+
 	return nil
 }
 
 // isSizeLabel checks if a label is a size label.
 func isSizeLabel(labelName string, labelConfigs []ConfigEntry) bool {
-	for _, configLabel := range labelConfigs {
-		if contains(configLabel.Labels, labelName) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(labelConfigs, func(entry ConfigEntry) bool {
+		return slices.Contains(entry.Labels, labelName)
+	})
 }
 
 // labelExists checks if a label already exists on a pull request.
 func labelExists(pr *github.PullRequest, labelName string) bool {
-	for _, label := range pr.Labels {
-		if label.GetName() == labelName {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(pr.Labels, func(label *github.Label) bool {
+		return label.GetName() == labelName
+	})
 }
 
 // calculateSizeAndDiff calculates the size and diff for the pull request.
@@ -316,29 +325,33 @@ func calculateSizeAndDiff(files []*github.CommitFile, config Config) (int, int) 
 			continue
 		}
 
-		if !shouldExcludeFile(file.GetFilename(), config.ExcludeFiles) {
-			numberOfFiles++
+		if shouldExcludeFile(file.GetFilename(), config.ExcludeFiles) {
+			continue
+		}
 
-			if config.AddedLinesOnly {
-				numberOfLines += file.GetAdditions()
-			} else {
-				numberOfLines += file.GetChanges()
-			}
+		numberOfFiles++
+		if config.AddedLinesOnly {
+			numberOfLines += file.GetAdditions()
+		} else {
+			numberOfLines += file.GetChanges()
 		}
 	}
 	return numberOfFiles, numberOfLines
 }
 
 func mapNumberOfChangesToSize(numberOfFiles, numberOfLines int, config Config) (ConfigEntry, ConfigEntry) {
-	size := getSize(config.LabelConfigs, numberOfFiles, ParamNameFiles)
-	diff := getSize(config.LabelConfigs, numberOfLines, ParamNameDiff)
+	size := getSize(config.LabelConfigs, numberOfFiles, filesThreshold)
+	diff := getSize(config.LabelConfigs, numberOfLines, diffThreshold)
 	return size, diff
 }
 
 // shouldExcludeFile checks if a file should be excluded based on the configuration.
 func shouldExcludeFile(filename string, patterns []string) bool {
+	justFileName := filepath.Base(filename)
+
 	for _, pattern := range patterns {
-		// Check against the full path
+		// Check against the full path. filepath.Match only ever fails on a
+		// malformed pattern, so warning once per pattern is enough.
 		matched, err := filepath.Match(pattern, filename)
 		if err != nil {
 			fmt.Printf("Invalid pattern %s: %s\n", pattern, err)
@@ -348,52 +361,34 @@ func shouldExcludeFile(filename string, patterns []string) bool {
 			return true
 		}
 
-		// Extract just the file name and check the pattern again
-		justFileName := filepath.Base(filename)
-		matched, err = filepath.Match(pattern, justFileName)
-		if err != nil {
-			fmt.Printf("Invalid pattern %s: %s\n", pattern, err)
-			continue
-		}
-		if matched {
+		// Check the pattern against the file name alone.
+		if matched, _ := filepath.Match(pattern, justFileName); matched {
 			return true
 		}
 
 		// A trailing "/*" excludes the directory recursively, which filepath.Match
 		// cannot express because its wildcards never cross a separator.
-		if dir, ok := strings.CutSuffix(pattern, "/*"); ok {
-			if strings.HasPrefix(filename, dir+"/") {
-				return true
-			}
+		if dir, ok := strings.CutSuffix(pattern, "/*"); ok && strings.HasPrefix(filename, dir+"/") {
+			return true
 		}
 	}
 	return false
 }
 
 // getSize retrieves the size configuration based on the number of files or diffs.
-func getSize(configuration []ConfigEntry, currentCount int, paramName string) ConfigEntry {
-	for _, entry := range configuration {
-		var entryValue int
-		switch paramName {
-		case ParamNameFiles:
-			entryValue = entry.Files
-		case ParamNameDiff:
-			entryValue = entry.Diff
-		}
-
-		if currentCount <= entryValue {
-			return entry
-		}
+func getSize(configuration []ConfigEntry, currentCount int, threshold thresholdFunc) ConfigEntry {
+	i := slices.IndexFunc(configuration, func(entry ConfigEntry) bool {
+		return currentCount <= threshold(entry)
+	})
+	if i >= 0 {
+		return configuration[i]
 	}
 	return configuration[len(configuration)-1]
 }
 
 // getBiggestEntry determines the largest entry between two ConfigEntry objects based on the user-defined order.
 func getBiggestEntry(configEntries []ConfigEntry, size, diff ConfigEntry) ConfigEntry {
-	sizeIndex := findConfigEntryIndex(configEntries, size.Size)
-	diffIndex := findConfigEntryIndex(configEntries, diff.Size)
-
-	if sizeIndex >= diffIndex {
+	if findConfigEntryIndex(configEntries, size.Size) >= findConfigEntryIndex(configEntries, diff.Size) {
 		return size
 	}
 	return diff
@@ -401,18 +396,15 @@ func getBiggestEntry(configEntries []ConfigEntry, size, diff ConfigEntry) Config
 
 // findConfigEntryIndex finds the index of a ConfigEntry in the configuration based on size.
 func findConfigEntryIndex(entries []ConfigEntry, size string) int {
-	for i, entry := range entries {
-		if entry.Size == size {
-			return i
-		}
-	}
-	return -1
+	return slices.IndexFunc(entries, func(entry ConfigEntry) bool {
+		return entry.Size == size
+	})
 }
 
 // parseRepoOwner extracts the repository owner from the full repository name.
 func parseRepoOwner(repoName string) string {
-	parts := strings.Split(repoName, "/")
-	return parts[0]
+	owner, _, _ := strings.Cut(repoName, "/")
+	return owner
 }
 
 // parseRepoName extracts the repository name from the full repository name.
@@ -428,17 +420,4 @@ func parseRepoName(repoName string) string {
 func isValidRepoNameFormat(repoName string) bool {
 	parts := strings.Split(repoName, "/")
 	return len(parts) == 2 && parts[0] != "" && parts[1] != ""
-}
-
-// exitOnError terminates the program if an error is encountered.
-func exitOnError(action string, err error) {
-	if err != nil {
-		fmt.Printf("Error %s: %v\n", action, err)
-		os.Exit(1)
-	}
-}
-
-// contains checks if a slice of strings contains a given string.
-func contains(slice []string, item string) bool {
-	return slices.Contains(slice, item)
 }

--- a/cmd/pr-size-labeler-action/main.go
+++ b/cmd/pr-size-labeler-action/main.go
@@ -274,14 +274,15 @@ func (prp *PullRequestProcessor) updatePullRequestLabel(entry ConfigEntry) error
 		return err
 	}
 
-	for _, label := range entry.Labels {
-		if labelExists(pr, label) {
-			continue
-		}
+	missing := slices.DeleteFunc(slices.Clone(entry.Labels), func(label string) bool {
+		return labelExists(pr, label)
+	})
+	if len(missing) == 0 {
+		return nil
+	}
 
-		if _, _, err := prp.clientWrapper.client.Issues.AddLabelsToIssue(prp.ctx, prp.repoOwner, prp.repoName, prp.prNumber, []string{label}); err != nil {
-			return fmt.Errorf("adding label %q: %w", label, err)
-		}
+	if _, _, err := prp.clientWrapper.client.Issues.AddLabelsToIssue(prp.ctx, prp.repoOwner, prp.repoName, prp.prNumber, missing); err != nil {
+		return fmt.Errorf("adding labels %v: %w", missing, err)
 	}
 
 	return nil

--- a/cmd/pr-size-labeler-action/main_test.go
+++ b/cmd/pr-size-labeler-action/main_test.go
@@ -211,25 +211,25 @@ func TestGetSize(t *testing.T) {
 		name          string
 		configuration []ConfigEntry
 		currentCount  int
-		paramName     string
+		threshold     thresholdFunc
 		want          ConfigEntry
 	}{
 		// Tests for file count
-		{"Fewer files than XS threshold", configuration, 0, ParamNameFiles, xsConfig},
-		{"Files equal to S threshold", configuration, 10, ParamNameFiles, sConfig},
-		{"Files between S and M thresholds", configuration, 15, ParamNameFiles, mConfig},
-		{"More files than XL threshold", configuration, 105, ParamNameFiles, xlConfig},
+		{"Fewer files than XS threshold", configuration, 0, filesThreshold, xsConfig},
+		{"Files equal to S threshold", configuration, 10, filesThreshold, sConfig},
+		{"Files between S and M thresholds", configuration, 15, filesThreshold, mConfig},
+		{"More files than XL threshold", configuration, 105, filesThreshold, xlConfig},
 
 		// Tests for diff count
-		{"Fewer changes than XS threshold", configuration, 5, ParamNameDiff, xsConfig},
-		{"Changes equal to M threshold", configuration, 100, ParamNameDiff, mConfig},
-		{"Changes between S and M thresholds", configuration, 35, ParamNameDiff, sConfig},
-		{"More changes than XL threshold", configuration, 1500, ParamNameDiff, xlConfig},
+		{"Fewer changes than XS threshold", configuration, 5, diffThreshold, xsConfig},
+		{"Changes equal to M threshold", configuration, 100, diffThreshold, mConfig},
+		{"Changes between S and M thresholds", configuration, 35, diffThreshold, sConfig},
+		{"More changes than XL threshold", configuration, 1500, diffThreshold, xlConfig},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := getSize(tt.configuration, tt.currentCount, tt.paramName)
+			got := getSize(tt.configuration, tt.currentCount, tt.threshold)
 			if !configEntriesAreEqual(got, tt.want) {
 				t.Errorf("getSize() = %v, want %v", got, tt.want)
 			}
@@ -370,41 +370,8 @@ func TestIsValidRepoNameFormat(t *testing.T) {
 	}
 }
 
-func TestContains(t *testing.T) {
-	tests := []struct {
-		name  string
-		slice []string
-		item  string
-		want  bool
-	}{
-		{"Present", []string{"a", "b", "c"}, "b", true},
-		{"NotPresent", []string{"a", "b", "c"}, "d", false},
-		{"EmptySlice", []string{}, "a", false},
-		{"EmptyString", []string{"a", "b", ""}, "", true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := contains(tt.slice, tt.item); got != tt.want {
-				t.Errorf("contains() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func configEntriesAreEqual(a, b ConfigEntry) bool {
-	if a.Size != b.Size || a.Diff != b.Diff || a.Files != b.Files {
-		return false
-	}
-	if len(a.Labels) != len(b.Labels) {
-		return false
-	}
-	for i, label := range a.Labels {
-		if label != b.Labels[i] {
-			return false
-		}
-	}
-	return true
+	return a.Size == b.Size && a.Diff == b.Diff && a.Files == b.Files && slices.Equal(a.Labels, b.Labels)
 }
 
 func mockCommitFile(filename string, status string, changes int, additions int) *github.CommitFile {
@@ -583,7 +550,7 @@ func TestShouldExcludeFile(t *testing.T) {
 
 // newTestProcessor spins up a stub GitHub API served by handler and returns a
 // processor wired to it.
-func newTestProcessor(t *testing.T, handler http.Handler) *PullRequestProcessor {
+func newTestProcessor(t *testing.T, config Config, handler http.Handler) *PullRequestProcessor {
 	t.Helper()
 
 	server := httptest.NewServer(handler)
@@ -595,7 +562,7 @@ func newTestProcessor(t *testing.T, handler http.Handler) *PullRequestProcessor 
 		t.Fatalf("creating GitHub client: %v", err)
 	}
 
-	return NewPullRequestProcessor(t.Context(), &GitHubClientWrapper{client: client}, "cbrgm", "pr-size-labeler-action", 1, Config{})
+	return NewPullRequestProcessor(t.Context(), &GitHubClientWrapper{client: client}, "cbrgm", "pr-size-labeler-action", 1, config)
 }
 
 func TestFetchPullRequestFilesFollowsPagination(t *testing.T) {
@@ -631,7 +598,7 @@ func TestFetchPullRequestFilesFollowsPagination(t *testing.T) {
 		}
 	})
 
-	files, err := newTestProcessor(t, mux).fetchPullRequestFiles()
+	files, err := newTestProcessor(t, Config{}, mux).fetchPullRequestFiles()
 	if err != nil {
 		t.Fatalf("fetchPullRequestFiles() returned error: %v", err)
 	}
@@ -657,7 +624,7 @@ func TestFetchPullRequestFilesReturnsError(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	})
 
-	files, err := newTestProcessor(t, mux).fetchPullRequestFiles()
+	files, err := newTestProcessor(t, Config{}, mux).fetchPullRequestFiles()
 	if err == nil {
 		t.Fatalf("fetchPullRequestFiles() = %v, want error", files)
 	}

--- a/cmd/pr-size-labeler-action/main_test.go
+++ b/cmd/pr-size-labeler-action/main_test.go
@@ -665,3 +665,45 @@ func TestFetchPullRequestFilesReturnsError(t *testing.T) {
 		t.Errorf("fetchPullRequestFiles() = %v, want nil files on error", files)
 	}
 }
+
+func TestShouldExcludeFileDirectoryPatternRespectsBoundary(t *testing.T) {
+	tests := []struct {
+		name       string
+		filename   string
+		patterns   []string
+		wantResult bool
+	}{
+		{
+			name:       "exclude file inside the directory",
+			filename:   "docs/guide.md",
+			patterns:   []string{"docs/*"},
+			wantResult: true,
+		},
+		{
+			name:       "exclude file nested deeper in the directory",
+			filename:   "docs/api/guide.md",
+			patterns:   []string{"docs/*"},
+			wantResult: true,
+		},
+		{
+			name:       "do not exclude a sibling directory sharing the prefix",
+			filename:   "docsite/guide.md",
+			patterns:   []string{"docs/*"},
+			wantResult: false,
+		},
+		{
+			name:       "do not exclude a file sharing the prefix",
+			filename:   "docs.go",
+			patterns:   []string{"docs/*"},
+			wantResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldExcludeFile(tt.filename, tt.patterns); got != tt.wantResult {
+				t.Errorf("shouldExcludeFile(%q, %v) = %v, want %v", tt.filename, tt.patterns, got, tt.wantResult)
+			}
+		})
+	}
+}

--- a/cmd/pr-size-labeler-action/main_test.go
+++ b/cmd/pr-size-labeler-action/main_test.go
@@ -707,3 +707,44 @@ func TestShouldExcludeFileDirectoryPatternRespectsBoundary(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr bool
+	}{
+		{
+			name:    "no label configs is rejected",
+			config:  Config{},
+			wantErr: true,
+		},
+		{
+			name:    "entry without a size is rejected",
+			config:  Config{LabelConfigs: []ConfigEntry{{Files: 1, Diff: 10, Labels: []string{"size/xs"}}}},
+			wantErr: true,
+		},
+		{
+			name:    "entry without labels is rejected",
+			config:  Config{LabelConfigs: []ConfigEntry{{Size: "xs", Files: 1, Diff: 10}}},
+			wantErr: true,
+		},
+		{
+			name: "valid config is accepted",
+			config: Config{LabelConfigs: []ConfigEntry{
+				{Size: "xs", Files: 1, Diff: 10, Labels: []string{"size/xs"}},
+				{Size: "s", Files: 10, Diff: 100, Labels: []string{"size/s"}},
+			}},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConfig(tt.config)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/pr-size-labeler-action/main_test.go
+++ b/cmd/pr-size-labeler-action/main_test.go
@@ -715,3 +715,76 @@ func TestValidateConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdatePullRequestLabelSwapsSizeLabels(t *testing.T) {
+	config := Config{LabelConfigs: []ConfigEntry{
+		{Size: "xs", Files: 1, Diff: 10, Labels: []string{"size/xs"}},
+		{Size: "l", Files: 50, Diff: 500, Labels: []string{"size/l", "pairing-wanted"}},
+	}}
+
+	var (
+		removed []string
+		added   [][]string
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/cbrgm/pr-size-labeler-action/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		pr := &github.PullRequest{Labels: []*github.Label{
+			{Name: "size/xs"},
+			{Name: "needs-review"},
+		}}
+		if err := json.NewEncoder(w).Encode(pr); err != nil {
+			t.Errorf("encoding response: %v", err)
+		}
+	})
+	mux.HandleFunc("DELETE /repos/cbrgm/pr-size-labeler-action/issues/1/labels/{name...}", func(w http.ResponseWriter, r *http.Request) {
+		removed = append(removed, r.PathValue("name"))
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("POST /repos/cbrgm/pr-size-labeler-action/issues/1/labels", func(w http.ResponseWriter, r *http.Request) {
+		var labels []string
+		if err := json.NewDecoder(r.Body).Decode(&labels); err != nil {
+			t.Errorf("decoding request: %v", err)
+		}
+		added = append(added, labels)
+		if err := json.NewEncoder(w).Encode([]*github.Label{}); err != nil {
+			t.Errorf("encoding response: %v", err)
+		}
+	})
+
+	entry := config.LabelConfigs[1]
+	if err := newTestProcessor(t, config, mux).updatePullRequestLabel(entry); err != nil {
+		t.Fatalf("updatePullRequestLabel() returned error: %v", err)
+	}
+
+	if want := []string{"size/xs"}; !slices.Equal(removed, want) {
+		t.Errorf("removed labels = %v, want %v", removed, want)
+	}
+	if len(added) != 1 {
+		t.Fatalf("add label requests = %d, want 1", len(added))
+	}
+	if want := []string{"size/l", "pairing-wanted"}; !slices.Equal(added[0], want) {
+		t.Errorf("added labels = %v, want %v", added[0], want)
+	}
+}
+
+func TestUpdatePullRequestLabelKeepsLabelsAlreadyPresent(t *testing.T) {
+	config := Config{LabelConfigs: []ConfigEntry{
+		{Size: "xs", Files: 1, Diff: 10, Labels: []string{"size/xs"}},
+	}}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/cbrgm/pr-size-labeler-action/pulls/1", func(w http.ResponseWriter, _ *http.Request) {
+		pr := &github.PullRequest{Labels: []*github.Label{{Name: "size/xs"}}}
+		if err := json.NewEncoder(w).Encode(pr); err != nil {
+			t.Errorf("encoding response: %v", err)
+		}
+	})
+	mux.HandleFunc("/", func(_ http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected %s %s, the label is already correct", r.Method, r.URL.Path)
+	})
+
+	if err := newTestProcessor(t, config, mux).updatePullRequestLabel(config.LabelConfigs[0]); err != nil {
+		t.Fatalf("updatePullRequestLabel() returned error: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.26.5
 require (
 	github.com/alexflint/go-arg v1.6.1
 	github.com/google/go-github/v90 v90.0.0
-	golang.org/x/oauth2 v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
-golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## What

Four commits, the two fixes first so they can be reverted on their own:

- `fix(exclude)`: `docs/*` no longer swallows `docsite/guide.md` or `docs.go`
- `fix(config)`: an empty or missing `label_configs` fails with a readable error instead of panicking
- `refactor`: modern stdlib helpers, `run() error` instead of `os.Exit` scattered around, `golang.org/x/oauth2` dropped
- `perf(labels)`: all missing labels go up in one API call instead of one call per label

Coverage 48.9% -> 55.2%, `updatePullRequestLabel` had no tests at all before.


### Refactor

Mechanical stuff, no behavior change:

- `github.WithAuthToken` instead of a hand rolled oauth2 token source -> one dependency less in go.mod. Same `Authorization: Bearer` header, i checked the client source.
- `NewGitHubClientWrapper` returned `*GitHubClientWrapper` and called `os.Exit(1)` internally. Now it returns an error, `main` is a thin wrapper around `run() error`, errors go to stderr and get wrapped with `%w` + context. `exitOnError` is gone.
- `slices.Contains` / `ContainsFunc` / `IndexFunc` replace the manual search loops, the `contains()` wrapper around `slices.Contains` is dropped (and with it `TestContains`, testing the stdlib is not our job).
- `getSize` took a `paramName string` and switched on `"files"` / `"diff"`. It takes a threshold accessor now, so the stringly typed switch and both constants disappear.
- `removeOtherSizeLabels` needed five processor fields as arguments, its a method now.
- context is bound to SIGINT/SIGTERM.

- **`label_configs` order is load bearing and unchecked.** `getSize` returns the first entry whose threshold is >= the count, so the list has to be sorted ascending. Put `l` before `xs` and a 1 file PR gets labeled `l`, no warning. I did not add a sort check because it would start rejecting configs that work today by accident.
- `EnvArgs.Version()` prints `Revision` under the `Version:` label and `Version` right after it, cosmetic, left alone.
- An invalid `exclude_files` pattern still only warns and keeps going. Warning is now emitted once per pattern instead of twice per pattern per file.
